### PR TITLE
chore(showdex): merge upstream smogon/damage-calc to 37b0afa

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <tr>
       <th align="center">&nbsp;Currently <a href="https://github.com/doshidak/showdex-calc/releases/tag/v1.3.0"><s>v1.3.0</s></a>&nbsp;</th>
       <th align="center">&nbsp;Powering <a href="https://github.com/doshidak/showdex"><code>showdex</code></a> · <a href="https://github.com/doshidak/showdex/releases/tag/v1.3.0"><s>v1.3.0</s></a>&nbsp;</th>
-      <th align="center">&nbsp;Patches <a href="https://github.com/smogon/damage-calc/tree/master/calc"><code>@smogon/calc</code></a> · <a href="https://npmjs.com/package/@smogon/calc/v/0.11.0">v0.11.0</a> &rarr; <a href="https://github.com/doshidak/showdex-calc/commit/c4d171797e80f6a4cdd3e58818b2a6f81b2d5519"><code>c4d1717</code></a>&nbsp;</th>
+      <th align="center">&nbsp;Patches <a href="https://github.com/smogon/damage-calc/tree/master/calc"><code>@smogon/calc</code></a> · <a href="https://npmjs.com/package/@smogon/calc/v/0.11.0">v0.11.0</a> &rarr; <a href="https://github.com/doshidak/showdex-calc/commit/ed6816b5004b265dea1ebd205bc7eaf9ae04f995"><code>ed6816b</code></a>&nbsp;</th>
     </tr>
   </thead>
 </table>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -412,7 +412,7 @@ th {
     position: relative;
     margin: -1px -3px 0;
     display: inline-block;
-    width: 5em;
+    width: 5rem;
     border-radius: 8px;
 }
 .btn-wide {
@@ -505,7 +505,7 @@ th {
 /* header */
 .move-result-group {
     display: flex;
-    min-width: 50em;
+    min-width: 50rem;
     margin-top: 1em;
 }
 .move-result-subgroup {
@@ -648,15 +648,15 @@ table.field {
 }
 
 .import-team-text {
-    margin: 16px 0;
-    min-width: 27em;
-    min-height: 10em;
+    margin: 1rem 0;
+    min-width: 27rem;
+    min-height: 10rem;
     resize: vertical;
 }
 
 .import-name-text {
-	min-width: 26.3em;
-    min-height: 1em;
+	min-width: 26.3rem;
+    min-height: 1rem;
     overflow: auto;
     display: inline;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -412,7 +412,7 @@ th {
     position: relative;
     margin: -1px -3px 0;
     display: inline-block;
-    width: 5rem;
+    width: 5em;
     border-radius: 8px;
 }
 .btn-wide {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -129,7 +129,7 @@ $(".hp .base, .hp .evs, .hp .ivs, .hp .sps").bind("keyup change", function () {
 $(".at .base, .at .evs, .at .ivs, .at .sps").bind("keyup change", function () {
 	calcStat($(this).closest(".poke-info"), 'at');
 });
-$(".df .base, .df .evs, .df .ivs , .df.sps").bind("keyup change", function () {
+$(".df .base, .df .evs, .df .ivs , .df .sps").bind("keyup change", function () {
 	calcStat($(this).closest(".poke-info"), 'df');
 });
 $(".sa .base, .sa .evs, .sa .ivs, .sa .sps").bind("keyup change", function () {


### PR DESCRIPTION
Syncs 3 commits from `smogon/damage-calc` (`babd8ba..37b0afa`). **No changes to `calc/` src or dist** — all upstream changes are web UI / set-import controls only:

- [Champions: Fix defense stat updates (#793)](https://github.com/smogon/damage-calc/commit/0e565b3) — `shared_controls.js` UI
- [Fix layout breaking due to font scaling (#790)](https://github.com/smogon/damage-calc/commit/adf1206) — `main.css`
- [Switch buttons back to em](https://github.com/smogon/damage-calc/commit/37b0afa) — `main.css`

Merged for fork hygiene; the `@smogon/calc` patch consumed by `showdex` is **unchanged** from the prior sync (`c4d1717`), so no follow-up patch update is needed on the showdex side.

### Showdex mods preserved (no conflicts in this merge)

- `ShowdexCalcMods` plumbing through `calculate()`
- `modBaseDamage` / `strikes` / `hitBasePowers` across all gen mechanics
- `excludeHazardsDamage` / `excludeEotDamage` in `desc.ts`
- `overrideOffensiveStat` / `overrideDefensiveStat` in all gen mechanics

### Test plan

- [x] `pnpm install` — postinstall (`tsc --build --force`) compiles clean
- [x] `git diff master..HEAD -- calc/` — empty (calc untouched)
- [x] No need to verify Showdex build — patch bytes are byte-for-byte identical to `c4d1717`